### PR TITLE
适配了nginx对http2协议的更改

### DIFF
--- a/conf/example/enable-lnmpa-ssl-vhost-example.conf
+++ b/conf/example/enable-lnmpa-ssl-vhost-example.conf
@@ -1,7 +1,7 @@
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name     lnmp.org www.lnmp.org;
         index index.html index.htm index.php default.html default.htm default.php;
         root  /home/wwwroot/lnmp.org;

--- a/conf/example/enable-ssl-example-letsencrypt-with-301.conf
+++ b/conf/example/enable-ssl-example-letsencrypt-with-301.conf
@@ -1,7 +1,7 @@
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name  lnmp.org www.lnmp.org;
         index index.html index.htm index.php default.html default.htm default.php;
         root  /home/wwwroot/lnmp.org;

--- a/conf/example/enable-ssl-example-with-301.conf
+++ b/conf/example/enable-ssl-example-with-301.conf
@@ -1,7 +1,7 @@
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name  lnmp.org www.lnmp.org;
         index index.html index.htm index.php default.html default.htm default.php;
         root  /home/wwwroot/lnmp.org;

--- a/conf/example/enable-ssl-example.conf
+++ b/conf/example/enable-ssl-example.conf
@@ -1,7 +1,7 @@
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name  lnmp.org www.lnmp.org;
         index index.html index.htm index.php default.html default.htm default.php;
         root  /home/wwwroot/lnmp.org;

--- a/conf/example/magento2-example.conf
+++ b/conf/example/magento2-example.conf
@@ -202,8 +202,8 @@ server
 
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name     lnmp.org www.lnmp.org;
         index index.php;
         set $MAGE_ROOT /home/wwwroot/lnmp.org;

--- a/conf/example/nginx-reverse-proxy-example.conf
+++ b/conf/example/nginx-reverse-proxy-example.conf
@@ -26,8 +26,8 @@ server
 
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name example.com www.example.com;
 
         ssl_certificate /usr/local/nginx/conf/ssl/example.com.crt;

--- a/conf/example/owncloud-example.conf
+++ b/conf/example/owncloud-example.conf
@@ -104,8 +104,8 @@ server
 
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name lnmp.org www.lnmp.org;
         root /home/wwwroot/owncloud;
 

--- a/conf/lnmp
+++ b/conf/lnmp
@@ -1229,8 +1229,8 @@ Create_SSL_Config()
 
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name ${domain} ${moredomain};
         index index.html index.htm index.php default.html default.htm default.php;
         root  ${vhostdir};
@@ -1282,7 +1282,7 @@ EOF
     fi
 
     if [ "${enable_ipv6}" == "y" ]; then
-        sed -i 's/#listen \[::\]:443 ssl http2;/listen \[::\]:443 ssl http2;/g' /usr/local/nginx/conf/vhost/${domain}.conf
+        sed -i 's/#listen \[::\]:443 ssl ;/listen \[::\]:443 ssl ;/g' /usr/local/nginx/conf/vhost/${domain}.conf
     fi
 
     echo "Test Nginx configure file......"

--- a/conf/lnmpa
+++ b/conf/lnmpa
@@ -955,8 +955,8 @@ Create_SSL_Config()
 
 server
     {
-        listen 443 ssl http2;
-        #listen [::]:443 ssl http2;
+        listen 443 ssl ;
+        #listen [::]:443 ssl ;
         server_name ${domain} ${moredomain};
         index index.html index.htm index.php default.html default.htm default.php;
         root  ${vhostdir};
@@ -1007,7 +1007,7 @@ EOF
     fi
 
     if [ "${enable_ipv6}" == "y" ]; then
-        sed -i 's/#listen \[::\]:443 ssl http2;/listen \[::\]:443 ssl http2;/g' /usr/local/nginx/conf/vhost/${domain}.conf
+        sed -i 's/#listen \[::\]:443 ssl ;/listen \[::\]:443 ssl ;/g' /usr/local/nginx/conf/vhost/${domain}.conf
     fi
 
     echo "Test Nginx configure file......"


### PR DESCRIPTION
避免了在更新到nginx1.25.1后，制作站点时出现的warn报错。

Nginx在1.25.0版本中实验性的支持HTTP/3后，在1.25.1版本中弃用了listen指令的http2参数，单独加入了http2指令。

### the “listen … http2” directive is deprecated异常

如果Nginx1.25.1及以后版本中，进行如下方式的配置：

```
listen 443 ssl http2;

listen [::]:443 ssl http2;
```

当执行nginx -t进行检查配置或重启Nginx时，会提示如下错误：

```
 [warn] : the "listen ... http2" directive is deprecated, use the "http2" directive instead **in** /etc/nginx/conf.d/s.conf:12

nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead **in** /etc/nginx/conf.d/s.conf:12
```

主要原因就是在Nginx的配置文件中采用了上述旧的语法格式导致的。

此时，将对应的配置修改为如下方式即可：

```
listen       443 ssl;

listen       [::]:443 ssl;
```

同时，如果配置了ssl on，需要去掉ssl on配置。

修改完毕，重启Nginx即可生效。
参考：https://blog.csdn.net/wo541075754/article/details/132722406

